### PR TITLE
Update to publish assetlinks.json

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,20 @@
+[
+    {
+        "relation": [
+            "lookalikes/allowlist"
+        ],
+        "target": {
+            "namespace": "web",
+            "site": "https://bungie.net"
+        }
+    },
+    {
+        "relation": [
+            "lookalikes/allowlist"
+        ],
+        "target": {
+            "namespace": "web",
+            "site": "https://bungie-net.github.io"
+        }
+    }
+]

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,1 @@
+include: [".well-known"]


### PR DESCRIPTION
Publishes a `.well-known/assetlinks.json` resource, which Chromium browsers utilize to recognize lookalike domains, like bungie-net.github.io and bungie.net. This will prevent Chrome from showing a user warning accessing the site. However, bungie.net must also include these entries for their existing assetlinks.json resource to fully resolve this problem.

Fixes #7